### PR TITLE
Fix usage example script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+.pytest_cache/
 
 # C extensions
 *.so

--- a/average_calculation.py
+++ b/average_calculation.py
@@ -24,29 +24,63 @@ from autoria.api import RiaAPI, RiaAverageCarPrice
 # the rest of them is optional
 
 api = RiaAPI()
+search_params = {
+    'category': 'Легковые',
+    'mark': 'Mitsubishi',
+    'model': 'ASX',
+    # 'bodystyle': '',
+    'years': [2015, 2017],
+    # 'state': 'Винницкая',
+    # 'city': 'Винница',
+    'gears': ['Автомат'],
+    # 'opts': ['ABS'],
+    # 'mileage': [10, 200],
+    # 'fuels': ['Дизель'],
+    # 'drives': ['Полный'],
+    # 'color': 'Серый',
+    # 'engine_volume': 1.5,
+    # 'seats': 5,
+    # 'doors': 3,
+    # 'carrying': 1500,
+    'custom': False,
+    'damage': False,
+    'under_credit': False,
+    'confiscated': False,
+    'on_repair_parts': False
+}
 myCarAveragePrice = RiaAverageCarPrice(
-    category='Легковые',
-    mark='Renault',
-    model='Sceni',
-    # bodystyle=None,
-    # years=[2006, 2007],
-    state='Винницкая',
-    city='Винница',
-    # gears=['Механика'],
-    # opts=['ABS'],
-    # mileage=[10, 200],
-    # fuels=['Дизель'],
-    # drives=['Полный'],
-    # color='Серый',
-    # engine_volume=1.5,
-    # seats=5,
-    # doors=3,
-    # carrying=1500,
-    custom=False,
-    damage=False,
-    under_credit=False,
-    confiscated=False,
-    on_repair_parts=False
+    category=search_params.get('category'),
+    mark=search_params.get('mark'),
+    model=search_params.get('model'),
+    bodystyle=search_params.get('bodystyle'),
+    years=search_params.get('years'),
+    state=search_params.get('state'),
+    city=search_params.get('city'),
+    gears=search_params.get('gears'),
+    opts=search_params.get('opts'),
+    mileage=search_params.get('mileage'),
+    fuels=search_params.get('fuels'),
+    drives=search_params.get('drives'),
+    color=search_params.get('color'),
+    engine_volume=search_params.get('engine_volume'),
+    seats=search_params.get('seats'),
+    doors=search_params.get('doors'),
+    carrying=search_params.get('carrying'),
+    custom=search_params.get('custom'),
+    damage=search_params.get('damage'),
+    under_credit=search_params.get('under_credit'),
+    confiscated=search_params.get('confiscated'),
+    on_repair_parts=search_params.get('on_repair_parts')
 )
 
-pprint(myCarAveragePrice.get_average())
+base_url = "https://auto.ria.com/auto__{}.html"
+average = myCarAveragePrice.get_average()
+
+report = {
+    'search_params': search_params,
+    'average': average,
+    'classifieds_urls': [
+        base_url.format(item)
+        for item in average.get('classifieds')]
+}
+pprint(report)

--- a/average_calculation.py
+++ b/average_calculation.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Python auto.ria.com API.
 
 Python implementation of API intended for calulating
@@ -14,8 +16,11 @@ print(api.get_fuels())
 print(api.get_colors())
 """
 
+from math import ceil
 from pprint import pprint
+
 from autoria.api import RiaAPI, RiaAverageCarPrice
+
 # not implemented yet
 # VEHICLE_MIN_PRICE = '4000'
 # VEHICLE_MAX_PRICE = '5000'
@@ -26,16 +31,16 @@ from autoria.api import RiaAPI, RiaAverageCarPrice
 api = RiaAPI()
 search_params = {
     'category': 'Легковые',
-    'mark': 'Mitsubishi',
-    'model': 'ASX',
-    # 'bodystyle': '',
+    'mark': 'Mazda',
+    'model': 'CX-5',
+    'bodystyle': 'Внедорожник / Кроссовер',
     'years': [2015, 2017],
     # 'state': 'Винницкая',
     # 'city': 'Винница',
     'gears': ['Автомат'],
     # 'opts': ['ABS'],
     # 'mileage': [10, 200],
-    # 'fuels': ['Дизель'],
+    'fuels': ['Дизель'],
     # 'drives': ['Полный'],
     # 'color': 'Серый',
     # 'engine_volume': 1.5,
@@ -48,30 +53,8 @@ search_params = {
     'confiscated': False,
     'on_repair_parts': False
 }
-myCarAveragePrice = RiaAverageCarPrice(
-    category=search_params.get('category'),
-    mark=search_params.get('mark'),
-    model=search_params.get('model'),
-    bodystyle=search_params.get('bodystyle'),
-    years=search_params.get('years'),
-    state=search_params.get('state'),
-    city=search_params.get('city'),
-    gears=search_params.get('gears'),
-    opts=search_params.get('opts'),
-    mileage=search_params.get('mileage'),
-    fuels=search_params.get('fuels'),
-    drives=search_params.get('drives'),
-    color=search_params.get('color'),
-    engine_volume=search_params.get('engine_volume'),
-    seats=search_params.get('seats'),
-    doors=search_params.get('doors'),
-    carrying=search_params.get('carrying'),
-    custom=search_params.get('custom'),
-    damage=search_params.get('damage'),
-    under_credit=search_params.get('under_credit'),
-    confiscated=search_params.get('confiscated'),
-    on_repair_parts=search_params.get('on_repair_parts')
-)
+
+myCarAveragePrice = RiaAverageCarPrice(**search_params)
 
 base_url = "https://auto.ria.com/auto__{}.html"
 average = myCarAveragePrice.get_average()
@@ -80,7 +63,8 @@ report = {
     'search_params': search_params,
     'average': average,
     'classifieds_urls': [
-        base_url.format(item)
-        for item in average.get('classifieds')]
+        ['${}'.format(ceil(price)), base_url.format(item)]
+        for price, item in zip(
+            average.get('prices'), average.get('classifieds'))]
 }
 pprint(report)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ flake8 # lint Python
 pylint
 mypy
 requests_mock # create mocks for ``requests``
-pytest-catchlog # Capture logging for tests


### PR DESCRIPTION
Hi @serebrov !
What do you think about such an enhancement for sample usage script? It prints a report in a nicer way, e.g.:
```
{'average': {'arithmeticMean': 15719.8,
             'classifieds': [23526325, 23423939, 23619124, 22956273, 23000097],
             'interQuartileMean': 15866.666666666666,
             'percentiles': {'1.0': 12139.039999999999,
                             '25.0': 15500,
                             '5.0': 12699.2,
                             '50.0': 15600,
                             '75.0': 16500,
                             '95.0': 18500,
                             '99.0': 18900},
             'prices': [16500, 15600, 19000, 11999, 15500],
             'total': 5},
 'classifieds_urls': ['https://auto.ria.com/auto__23526325.html',
                      'https://auto.ria.com/auto__23423939.html',
                      'https://auto.ria.com/auto__23619124.html',
                      'https://auto.ria.com/auto__22956273.html',
                      'https://auto.ria.com/auto__23000097.html'],
 'search_params': {'category': 'Легковые',
                   'confiscated': False,
                   'custom': False,
                   'damage': False,
                   'gears': ['Автомат'],
                   'mark': 'Mitsubishi',
                   'model': 'ASX',
                   'on_repair_parts': False,
                   'under_credit': False,
                   'years': [2015, 2017]}}
```